### PR TITLE
Updated airsonic to 10.2.1

### DIFF
--- a/HomebrewFormula/airsonic.rb
+++ b/HomebrewFormula/airsonic.rb
@@ -1,9 +1,9 @@
 class Airsonic < Formula
   desc "Free and Open Source media streaming server (fork of Subsonic and Libresonic)"
   homepage "https://airsonic.github.io/docs/"
-  url "https://github.com/airsonic/airsonic/releases/download/v10.1.2/airsonic.war"
-  version "10.1.2"
-  sha256 "738c0614a113f692d75f62d9a74efab1580e3ba8c683feb8d6bfded80240f342"
+  url "https://github.com/airsonic/airsonic/releases/download/v10.2.1/airsonic.war"
+  version "10.2.1"
+  sha256 "9bd4e9651df1a15278fb6414d011bd5a45c037857e84eaeb1375b26c717a5ebe"
 
   depends_on :java
   depends_on "ffmpeg" => ["with-fdk-aac"]

--- a/HomebrewFormula/airsonic.rb
+++ b/HomebrewFormula/airsonic.rb
@@ -1,9 +1,9 @@
 class Airsonic < Formula
   desc "Free and Open Source media streaming server (fork of Subsonic and Libresonic)"
   homepage "https://airsonic.github.io/docs/"
-  url "https://github.com/airsonic/airsonic/releases/download/v10.1.1/airsonic.war"
-  version "10.1.1"
-  sha256 "2647f2fcbd54c5c9a474fcadf8f479d17d4428d59b460b6e73cb528414359229"
+  url "https://github.com/airsonic/airsonic/releases/download/v10.1.2/airsonic.war"
+  version "10.1.2"
+  sha256 "738c0614a113f692d75f62d9a74efab1580e3ba8c683feb8d6bfded80240f342"
 
   depends_on :java
   depends_on "ffmpeg" => ["with-fdk-aac"]


### PR DESCRIPTION
Successfully upgrade Homebrew formula for airsonic 10.1.2.

```
~/D/homebrew-airsonic ❯❯❯ brew install hijxf/airsonic/airsonic                                                            ✘ 1 master
==> Installing airsonic from hijxf/airsonic
==> Installing dependencies for hijxf/airsonic/airsonic: libvpx, opus, sdl2, snappy, theora, x265 and ffmpeg
==> Installing hijxf/airsonic/airsonic dependency: libvpx
==> Downloading https://homebrew.bintray.com/bottles/libvpx-1.7.0.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring libvpx-1.7.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libvpx/1.7.0: 17 files, 1.4MB
==> Installing hijxf/airsonic/airsonic dependency: opus
==> Downloading https://homebrew.bintray.com/bottles/opus-1.2.1.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring opus-1.2.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/opus/1.2.1: 16 files, 864.3KB
==> Installing hijxf/airsonic/airsonic dependency: sdl2
==> Downloading https://homebrew.bintray.com/bottles/sdl2-2.0.8.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring sdl2-2.0.8.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/sdl2/2.0.8: 86 files, 4.2MB
==> Installing hijxf/airsonic/airsonic dependency: snappy
==> Downloading https://homebrew.bintray.com/bottles/snappy-1.1.7_1.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring snappy-1.1.7_1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/snappy/1.1.7_1: 18 files, 115.8KB
==> Installing hijxf/airsonic/airsonic dependency: theora
==> Downloading https://homebrew.bintray.com/bottles/theora-1.1.1.mojave.bottle.2.tar.gz
######################################################################## 100.0%
==> Pouring theora-1.1.1.mojave.bottle.2.tar.gz
🍺  /usr/local/Cellar/theora/1.1.1: 97 files, 2MB
==> Installing hijxf/airsonic/airsonic dependency: x265
==> Downloading https://homebrew.bintray.com/bottles/x265-2.9.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring x265-2.9.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/x265/2.9: 11 files, 35.2MB
==> Installing hijxf/airsonic/airsonic dependency: ffmpeg
==> Downloading https://ffmpeg.org/releases/ffmpeg-4.0.2.tar.xz
Already downloaded: /Users/jef/Library/Caches/Homebrew/downloads/a9eeda9af7836d6e482d974f5f9979862c8d1b648ead2607b81cdabedf131965--ffmpeg-4.0.2.tar.xz
==> ./configure --prefix=/usr/local/Cellar/ffmpeg/4.0.2_1 --enable-shared --enable-pthreads --enable-version3 --enable-hardcoded-tabl
==> make install
==> make alltools
🍺  /usr/local/Cellar/ffmpeg/4.0.2_1: 282 files, 53.6MB, built in 17 minutes 5 seconds
==> Installing hijxf/airsonic/airsonic
==> Downloading https://github.com/airsonic/airsonic/releases/download/v10.1.2/airsonic.war
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/96242277/f086bc94-926f-11e8-8e36-3234c6d0dbaf?X-
######################################################################## 100.0%
==> Caveats
To have launchd start hijxf/airsonic/airsonic now and restart at login:
  brew services start hijxf/airsonic/airsonic
==> Summary
🍺  /usr/local/Cellar/airsonic/10.1.2: 4 files, 69.7MB, built in 11 seconds
==> Caveats
==> airsonic
To have launchd start hijxf/airsonic/airsonic now and restart at login:
  brew services start hijxf/airsonic/airsonic
```

![screenshot](https://i.imgur.com/d93l71f.png)