### PR TITLE
Updated airsonic to 10.4.0

### DIFF
--- a/HomebrewFormula/airsonic.rb
+++ b/HomebrewFormula/airsonic.rb
@@ -28,42 +28,42 @@ class Airsonic < Formula
   end
 
   def plist; <<-EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>EnableGlobbing</key>
-        <true/>
-        <key>ProgramArguments</key>
-        <array>
-          <string>java</string>
-          <string>--add-modules=java.se.ee</string>
-          <string>-XX:+IgnoreUnrecognizedVMOptions</string>
-          <string>-Xmx512m</string>
-          <string>-Dlogging.file=#{var}/log/airsonic.log</string>
-          <string>-Dlogging.level.root=ERROR</string>
-          <string>-Dserver.host=0.0.0.0</string>
-          <string>-Dserver.port=4040</string>
-          <string>-Dserver.context-path=/</string>
-          <string>-Dairsonic.home=#{workingdir}</string>
-          <string>-Djava.awt.headless=true</string>
-          <string>-jar</string>
-          <string>#{prefix}/airsonic.war</string>
-        </array>
-        <key>ServiceDescription</key>
-        <string>#{name}</string>
-        <key>WorkingDirectory</key>
-        <string>#{workingdir}</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/airsonic.log</string>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/airsonic.log</string>
-        <key>RunAtLoad</key>
-        <true/>
-      </dict>
-      </plist>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>#{plist_name}</string>
+  <key>EnableGlobbing</key>
+  <true/>
+  <key>ProgramArguments</key>
+  <array>
+    <string>java</string>
+    <string>--add-modules=java.se.ee</string>
+    <string>-XX:+IgnoreUnrecognizedVMOptions</string>
+    <string>-Xmx512m</string>
+    <string>-Dlogging.file=#{var}/log/airsonic.log</string>
+    <string>-Dlogging.level.root=ERROR</string>
+    <string>-Dserver.host=0.0.0.0</string>
+    <string>-Dserver.port=4040</string>
+    <string>-Dserver.context-path=/</string>
+    <string>-Dairsonic.home=#{workingdir}</string>
+    <string>-Djava.awt.headless=true</string>
+    <string>-jar</string>
+    <string>#{prefix}/airsonic.war</string>
+  </array>
+  <key>ServiceDescription</key>
+  <string>#{name}</string>
+  <key>WorkingDirectory</key>
+  <string>#{workingdir}</string>
+  <key>StandardErrorPath</key>
+  <string>#{var}/log/airsonic.log</string>
+  <key>StandardOutPath</key>
+  <string>#{var}/log/airsonic.log</string>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
     EOS
   end
 end

--- a/HomebrewFormula/airsonic.rb
+++ b/HomebrewFormula/airsonic.rb
@@ -1,9 +1,9 @@
 class Airsonic < Formula
   desc "Free and Open Source media streaming server (fork of Subsonic and Libresonic)"
   homepage "https://airsonic.github.io/docs/"
-  url "https://github.com/airsonic/airsonic/releases/download/v10.2.1/airsonic.war"
-  version "10.2.1"
-  sha256 "9bd4e9651df1a15278fb6414d011bd5a45c037857e84eaeb1375b26c717a5ebe"
+  url "https://github.com/airsonic/airsonic/releases/download/v10.3.1/airsonic.war"
+  version "10.3.1"
+  sha256 "262013041484faeed00bedfd4b3d8b6a3cec84db90b1020c028424ff0f34c597"
 
   depends_on :java
   depends_on "ffmpeg" => ["with-fdk-aac"]

--- a/HomebrewFormula/airsonic.rb
+++ b/HomebrewFormula/airsonic.rb
@@ -1,9 +1,9 @@
 class Airsonic < Formula
   desc "Free and Open Source media streaming server (fork of Subsonic and Libresonic)"
   homepage "https://airsonic.github.io/docs/"
-  url "https://github.com/airsonic/airsonic/releases/download/v10.3.1/airsonic.war"
-  version "10.3.1"
-  sha256 "262013041484faeed00bedfd4b3d8b6a3cec84db90b1020c028424ff0f34c597"
+  url "https://github.com/airsonic/airsonic/releases/download/v10.4.0/airsonic.war"
+  version "10.4.0"
+  sha256 "0842a1fc4380cbe75e40dcb94e40332222b816514bd8ad250501d472210894d4"
 
   depends_on :java
   depends_on "ffmpeg" => ["with-fdk-aac"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
-Airsonic Homebrew Tap
-=====================
+# Airsonic Homebrew Tap
 
 Free and Open Source media streaming server (fork of Subsonic and Libresonic)
 
-Installation
-------------
+## Installation
 
 ```
 $ brew tap airsonic/airsonic
 $ brew install airsonic
 ```
+
+## Updating settings
+
+Use your favorite text editor and open `$(brew --prefix)/Cellar/airsonic/10.4.0/homebrew.mxcl.airsonic.plist`
+
+Edit any of the following properties:
+
+```
+<string>-Xmx512m</string>  <!-- Max Memory -->
+<string>-Dlogging.file=/usr/local/var/log/airsonic.log</string>
+<string>-Dlogging.level.root=ERROR</string>
+<string>-Dserver.host=0.0.0.0</string>
+<string>-Dserver.port=4040</string>
+<string>-Dserver.context-path=/</string>  <!-- localhost:port/context-path, e.g.: /airsonic -->
+<string>-Dairsonic.home=/usr/local/var/airsonic</string>
+<string>-Djava.awt.headless=true</string>
+<string>-jar</string>
+<string>/usr/local/Cellar/airsonic/10.4.0/airsonic.war</string>
+```
+
+> Source: https://airsonic.github.io/docs/install/homebrew/


### PR DESCRIPTION
Terminal Log:
```
~/Development/homebrew-airsonic master 7s
❯ brew upgrade hijxf/airsonic/airsonic
==> Upgrading 1 outdated package:
hijxf/airsonic/airsonic 10.2.1 -> 10.3.1
==> Upgrading hijxf/airsonic/airsonic
==> Installing dependencies for hijxf/airsonic/airsonic: libpng, freetype, p11-kit, libevent, unbound, gnutls, glib, pixman, harfbuzz, libbluray, openjpeg, opus, sdl2, leptonica and ffmpeg
==> Installing hijxf/airsonic/airsonic dependency: libpng
==> Downloading https://homebrew.bintray.com/bottles/libpng-1.6.37.mojave.bottle.ta
==> Downloading from https://akamai.bintray.com/53/53bbd14cc27c86c16605e256e7646a1b
######################################################################## 100.0%
==> Pouring libpng-1.6.37.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libpng/1.6.37: 27 files, 1.2MB
==> Installing hijxf/airsonic/airsonic dependency: freetype
==> Downloading https://homebrew.bintray.com/bottles/freetype-2.10.0.mojave.bottle.
==> Downloading from https://akamai.bintray.com/d2/d231ab6634051c4b655bbfc07cd5b306
######################################################################## 100.0%
==> Pouring freetype-2.10.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/freetype/2.10.0: 61 files, 2.3MB
==> Installing hijxf/airsonic/airsonic dependency: p11-kit
==> Downloading https://homebrew.bintray.com/bottles/p11-kit-0.23.16.1.mojave.bottl
==> Downloading from https://akamai.bintray.com/49/49ffd7c971e56e2ef825e7af091064c3
######################################################################## 100.0%
==> Pouring p11-kit-0.23.16.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/p11-kit/0.23.16.1: 63 files, 2.9MB
==> Installing hijxf/airsonic/airsonic dependency: libevent
==> Downloading https://homebrew.bintray.com/bottles/libevent-2.1.10.mojave.bottle.
==> Downloading from https://akamai.bintray.com/3f/3f43999f92de5174fa646e00cb099880
######################################################################## 100.0%
==> Pouring libevent-2.1.10.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libevent/2.1.10: 857 files, 2.2MB
==> Installing hijxf/airsonic/airsonic dependency: unbound
==> Downloading https://homebrew.bintray.com/bottles/unbound-1.9.1_1.mojave.bottle.
==> Downloading from https://akamai.bintray.com/38/3897bcc25b36315cbda263d5048f608f
######################################################################## 100.0%
==> Pouring unbound-1.9.1_1.mojave.bottle.tar.gz
==> Caveats
To have launchd start unbound now and restart at startup:
  sudo brew services start unbound
==> Summary
🍺  /usr/local/Cellar/unbound/1.9.1_1: 56 files, 4.8MB
==> Installing hijxf/airsonic/airsonic dependency: gnutls
==> Downloading https://homebrew.bintray.com/bottles/gnutls-3.6.8.mojave.bottle.tar
==> Downloading from https://akamai.bintray.com/66/6679cf795332813d1e41778272f3e828
######################################################################## 100.0%
==> Pouring gnutls-3.6.8.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/gnutls/3.6.8: 1,208 files, 9.3MB
==> Installing hijxf/airsonic/airsonic dependency: glib
==> Downloading https://homebrew.bintray.com/bottles/glib-2.60.3.mojave.bottle.tar.
==> Downloading from https://akamai.bintray.com/e5/e56cc0fef34e30a8017278f44c50b337
######################################################################## 100.0%
==> Pouring glib-2.60.3.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/glib/2.60.3: 429 files, 15.3MB
==> Installing hijxf/airsonic/airsonic dependency: pixman
==> Downloading https://homebrew.bintray.com/bottles/pixman-0.38.4.mojave.bottle.ta
==> Downloading from https://akamai.bintray.com/39/3990b771ee29451c8a9bcb6cb077205a
######################################################################## 100.0%
==> Pouring pixman-0.38.4.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/pixman/0.38.4: 13 files, 1.3MB
==> Installing hijxf/airsonic/airsonic dependency: harfbuzz
==> Downloading https://homebrew.bintray.com/bottles/harfbuzz-2.5.1.mojave.bottle.t
==> Downloading from https://akamai.bintray.com/7c/7c1600969389cebd8b32c9f0331831f1
######################################################################## 100.0%
==> Pouring harfbuzz-2.5.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/harfbuzz/2.5.1: 151 files, 10.0MB
==> Installing hijxf/airsonic/airsonic dependency: libbluray
==> Downloading https://homebrew.bintray.com/bottles/libbluray-1.1.1.mojave.bottle.
==> Downloading from https://akamai.bintray.com/24/24eef45b0f6eb3bb19ae609d7dda031f
######################################################################## 100.0%
==> Pouring libbluray-1.1.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/libbluray/1.1.1: 21 files, 1.5MB
==> Installing hijxf/airsonic/airsonic dependency: openjpeg
==> Downloading https://homebrew.bintray.com/bottles/openjpeg-2.3.1.mojave.bottle.t
==> Downloading from https://akamai.bintray.com/6d/6de317bfef3ab808ff5f3eb9c1aa47f7
######################################################################## 100.0%
==> Pouring openjpeg-2.3.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/openjpeg/2.3.1: 516 files, 12.8MB
==> Installing hijxf/airsonic/airsonic dependency: opus
==> Downloading https://homebrew.bintray.com/bottles/opus-1.3.1.mojave.bottle.tar.g
==> Downloading from https://akamai.bintray.com/78/787bf9b6d56f63cc3d0cf0f7f17affeb
######################################################################## 100.0%
==> Pouring opus-1.3.1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/opus/1.3.1: 17 files, 982.3KB
==> Installing hijxf/airsonic/airsonic dependency: sdl2
==> Downloading https://homebrew.bintray.com/bottles/sdl2-2.0.9_1.mojave.bottle.tar
==> Downloading from https://akamai.bintray.com/73/73dc083fe09bef54cdd08d6e1d86fba6
######################################################################## 100.0%
==> Pouring sdl2-2.0.9_1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/sdl2/2.0.9_1: 87 files, 4.5MB
==> Installing hijxf/airsonic/airsonic dependency: leptonica
==> Downloading https://homebrew.bintray.com/bottles/leptonica-1.78.0.mojave.bottle
==> Downloading from https://akamai.bintray.com/53/534b5e4c96c34aed7f2e3dd9ffc046fd
######################################################################## 100.0%
==> Pouring leptonica-1.78.0.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/leptonica/1.78.0: 49 files, 5.9MB
==> Installing hijxf/airsonic/airsonic dependency: ffmpeg
==> Downloading https://homebrew.bintray.com/bottles/ffmpeg-4.1.3_1.mojave.bottle.t
==> Downloading from https://akamai.bintray.com/dd/ddfb58dd5432eed657d9ecda3b4c2f06
######################################################################## 100.0%
==> Pouring ffmpeg-4.1.3_1.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/ffmpeg/4.1.3_1: 282 files, 58.5MB
==> Installing hijxf/airsonic/airsonic
==> Downloading https://github.com/airsonic/airsonic/releases/download/v10.3.1/airs
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.co
######################################################################## 100.0%
==> Caveats
To have launchd start hijxf/airsonic/airsonic now and restart at login:
  brew services start hijxf/airsonic/airsonic
==> Summary
🍺  /usr/local/Cellar/airsonic/10.3.1: 4 files, 70.3MB, built in 18 seconds
Removing: /usr/local/Cellar/airsonic/10.2.1... (4 files, 65.6MB)
Removing: /Users/jef/Library/Caches/Homebrew/airsonic--10.2.1.war... (65.6MB)
==> Caveats
==> unbound
To have launchd start unbound now and restart at startup:
  sudo brew services start unbound
==> airsonic
To have launchd start hijxf/airsonic/airsonic now and restart at login:
  brew services start hijxf/airsonic/airsonic
```

Screenshots:
![airsonic](https://user-images.githubusercontent.com/12074633/59057921-7c4ee680-8869-11e9-92b9-116cd9ccd096.png)
